### PR TITLE
Fix software bug

### DIFF
--- a/docs/shaders/raymarchingChair.glsl
+++ b/docs/shaders/raymarchingChair.glsl
@@ -49,7 +49,7 @@ vec3 calcNormal(vec3 p){
         // ray origin(=カメラの位置)
         vec3 rayOrigin=vec3(0.,0.,3.);
         // ray direction(rayOrigin から描画位置へのベクトル)
-        vec3 rayDir = normalize(vec3(uv,0.));
+        vec3 rayDir = normalize(vec3(uv,-1.));
         
         float d=rayMarch(rayOrigin,rayDir,MIN_DIST,MAX_DIST);// distance to sphere
         

--- a/raymarchingChair/raymarchingChair.glsl
+++ b/raymarchingChair/raymarchingChair.glsl
@@ -49,7 +49,7 @@ vec3 calcNormal(vec3 p){
         // ray origin(=カメラの位置)
         vec3 rayOrigin=vec3(0.,0.,3.);
         // ray direction(rayOrigin から描画位置へのベクトル)
-        vec3 rayDir = normalize(vec3(uv,0.));
+        vec3 rayDir = normalize(vec3(uv,-1.));
         
         float d=rayMarch(rayOrigin,rayDir,MIN_DIST,MAX_DIST);// distance to sphere
         


### PR DESCRIPTION
Fix ray direction Z-component to point towards objects.

Previously, the Z-direction component of the ray was set to 0, causing rays to not intersect with objects. Changing it to -1 ensures rays point towards the scene, enabling proper rendering.