### PR TITLE
Investigate shader display issue on GitHub Page

### DIFF
--- a/docs/js/shader.js
+++ b/docs/js/shader.js
@@ -54,7 +54,7 @@ function createProgram(gl, vsSource, fsSource) {
 (async () => {
   // Load the shader relative to the HTML file rather than this module's path
   // so it works correctly when served from GitHub Pages.
-  let fs = await loadShaderSource('../shaders/raymarchingChair.glsl');
+  let fs = await loadShaderSource('shaders/raymarchingChair.glsl');
   const header = `#version 300 es\nprecision highp float;\nuniform vec3 iResolution;\nuniform float iTime;\nout vec4 outColor;\n`;
   const footer = `\nvoid main(){\n    mainImage(outColor, gl_FragCoord.xy);\n}`;
   const fsSource = header + fs + footer;


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Correct shader file path to enable display on GitHub Pages.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous relative path `../shaders/` caused a 404 error on GitHub Pages because it attempted to access a directory outside the repository's base URL. Changing it to `shaders/` resolves the path correctly relative to the `index.html` file.